### PR TITLE
[minor] avoid polymorphic comparisons rejected by Core v0.14

### DIFF
--- a/lib/winbat_format.ml
+++ b/lib/winbat_format.ml
@@ -41,7 +41,7 @@ let rec print_leftvalue
   =
   match lvalue with
   | `Identifier ident ->
-    if bare || ((String.get ident 0) = '%') then
+    if bare || (Char.equal (String.get ident 0) '%') then
       bprintf buf "%s" ident
     else
       bprintf buf "!%s!" ident
@@ -75,7 +75,7 @@ let rec print_arith buf (arith : arithmetic) =
   | `ArithUnary (operator, arith) ->
     bprintf buf "%s^(%a^)" operator print_arith arith
   | `ArithBinary (operator, left, right) -> (
-      let operator = if operator = "%" then "%%" else operator in
+      let operator = if String.equal operator "%" then "%%" else operator in
       bprintf buf "^(%a %s %a^)"
         print_arith left
         operator
@@ -145,7 +145,7 @@ let rec print_statement buf (stmt: statement) ~(indent: int) =
   | `Comment comment ->
     let len = String.length comment in
     bprintf buf "rem%s%s" (
-      if len = 0 || (len > 0 && (String.get comment 0) = ' ') then
+      if len = 0 || (len > 0 && Char.equal (String.get comment 0) ' ') then
         ""
       else
         " "

--- a/tests/main.ml
+++ b/tests/main.ml
@@ -8,7 +8,7 @@ let script_dir = "test_scripts"
 let drop_carrage_return str =
   let buffer = Buffer.create (String.length str) in
   String.iter str ~f:(fun ch ->
-      if ch <> '\r' then
+      if not (Char.equal ch '\r') then
         Buffer.add_char buffer ch
     );
   Buffer.contents buffer


### PR DESCRIPTION
Someone asked [on the Discuss thread](https://discuss.ocaml.org/t/compiling-batsh/4700/54?u=gasche) whether the recent bitrot-cleanup action was still effective with recent OCaml versions, so I tried. On a 4.10 switch, the build was broken because Core v0.14 made `=` and `<>` monomorphic (integer-only). This PR fixes the issue.